### PR TITLE
wrap `txn` method to give a DBIx::Handler::Sunny object

### DIFF
--- a/lib/DBIx/Handler/Sunny.pm
+++ b/lib/DBIx/Handler/Sunny.pm
@@ -49,6 +49,11 @@ sub last_insert_id {
     $self->dbh->last_insert_id(@_);
 }
 
+sub txn {
+    my ($self, $coderef) = @_;
+    $self->SUPER::txn(sub { $coderef->($self) });
+}
+
 1;
 __END__
 


### PR DESCRIPTION
Fixed this
```perl
my $handler = DBIx::Handler::Sunny->new(...);
$handler->txn(sub {
    my $db = shift; # DBIx::Handler
    # ...
});
```